### PR TITLE
Add Options section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ rollup({
 }).then(...)
 ```
 
+## Options
+
+- `include`: a [micromatch](https://github.com/micromatch/micromatch) pattern, or array of patterns, specifying files to include
+- `exclude`: a [micromatch](https://github.com/micromatch/micromatch) pattern, or array of patterns, specifying files to exclude
+- `transforms`: an object of transform options, per the [Buble docs](https://buble.surge.sh/guide/)
+
 ## License
 
 MIT


### PR DESCRIPTION
This change adds a brief description of options for `rollup-plugin-buble`, which may be helpful for newcomers.

Thanks!